### PR TITLE
Allows for no bot mentions in channels

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -8,6 +8,21 @@ import (
 	"github.com/joho/godotenv"
 )
 
+func GetNoPrefixChannelIds() map[string]int {
+	var idMap map[string]int
+	idMap = make(map[string]int)
+	channelIds, channelIdsProvided := os.LookupEnv("CHANNEL_IDS")
+	if !channelIdsProvided {
+		log.Fatalf("env var CHANNEL_IDS not set")
+	}
+
+	for _, element := range strings.Split(channelIds, ",") {
+		idMap[element] = 1
+	}
+
+	return idMap
+}
+
 func GetBotSlackID() string {
 	botId, botIdProvided := os.LookupEnv("SLACK_BOT_ID")
 	if !botIdProvided {

--- a/router/slack_event.go
+++ b/router/slack_event.go
@@ -58,7 +58,10 @@ func SlackEvents() {
 
 			case *slackevents.AppMentionEvent:
 				log.Printf("INF Recvd AppMentionedEvent %+v", ev)
-				go command.ProcessMessage(ev)
+				go command.ProcessAppMentionEvent(ev)
+			case *slackevents.MessageEvent:
+				log.Printf("INF Recvd MessageEvent %+v", ev)
+				go command.ProcessMessageEvent(ev)
 			}
 		}
 	})


### PR DESCRIPTION
- Fix the issue where the bot would replay a message in the main chat,
  now replies in a thread if the ask was in a thread
- Enable setting channel ids as ones that don't require a bot prefix,
  which means we not listen to message events and might need to reject
  them sooner